### PR TITLE
fix: adjust pgdata volume mount for pg 18+

### DIFF
--- a/extra/docker-compose/postgresql/docker-compose.yml
+++ b/extra/docker-compose/postgresql/docker-compose.yml
@@ -2,7 +2,7 @@ services:
   postgres:
     image: postgres
     volumes:
-      - postgres-vol:/var/lib/postgresql/data
+      - postgres-vol:/var/lib/postgresql
     ports:
       - "5432:5432"
     environment:


### PR DESCRIPTION
with pg 18 the default data folder has changed. the sample compose does not work anymore. either pin to earlier postgres or adjust the path as I did in this PR.